### PR TITLE
fix: remove invalid input size props

### DIFF
--- a/apps/portal/src/pages/avaliacoes/index.tsx
+++ b/apps/portal/src/pages/avaliacoes/index.tsx
@@ -435,7 +435,6 @@ export default function AvaliacoesPage() {
                               </div>
                               <div className="col-span-2">
                                 <Input
-                                  size="sm"
                                   placeholder="0,0"
                                   value={notasEditadas[estudante.alunoId]?.nota || ''}
                                   onChange={(e) => updateGrade(estudante.alunoId, 'nota', e.target.value)}
@@ -451,7 +450,6 @@ export default function AvaliacoesPage() {
                               </div>
                               <div className="col-span-3">
                                 <Input
-                                  size="sm"
                                   placeholder="Observações..."
                                   value={notasEditadas[estudante.alunoId]?.obs || ''}
                                   onChange={(e) => updateGrade(estudante.alunoId, 'obs', e.target.value)}


### PR DESCRIPTION
## Summary
- remove the unsupported `size` prop from grade inputs so they no longer violate the HTML input typings

## Testing
- pnpm --filter @seminario/portal type-check

------
https://chatgpt.com/codex/tasks/task_e_68cdb166d3f48332a979b539e7043601