### PR TITLE
Optimize Coolify build resource usage

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,20 @@
+[variables]
+NODE_ENV = "production"
+TURBO_TELEMETRY_DISABLED = "1"
+
+[phases.setup]
+nixPkgs = ["nodejs_18", "pnpm"]
+
+[phases.install]
+cmds = [
+  "corepack enable",
+  "pnpm install --frozen-lockfile --filter \"@seminario/api...\" --filter \"@seminario/portal...\" --filter \"@seminario/shared-auth...\" --filter \"@seminario/shared-config...\" --filter \"@seminario/shared-dtos...\" --filter '!@seminario/shared-tests'"
+]
+
+[phases.build]
+cmds = [
+  "pnpm turbo run build --concurrency=1 --no-daemon --filter \"@seminario/api...\" --filter \"@seminario/portal...\" --filter '!@seminario/shared-tests'"
+]
+
+[start]
+cmd = "bash scripts/nixpacks-start.sh"

--- a/scripts/nixpacks-start.sh
+++ b/scripts/nixpacks-start.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper used in Nixpacks/Coolify deployments to reuse the production start flow
+# while keeping the entrypoint explicit for the buildpack configuration.
+
+echo "🚀 Booting application via Nixpacks start wrapper"
+exec ./scripts/start-production.sh


### PR DESCRIPTION
## Summary
- document and configure a leaner Coolify/Nixpacks pipeline that avoids parallel builds and unnecessary workspaces
- add a dedicated start wrapper so Nixpacks reuses the production bootstrap script and migrations

## Testing
- `pnpm turbo run build --concurrency=1 --filter "@seminario/api..." --filter "@seminario/portal..." --filter '!@seminario/shared-tests'`


------
https://chatgpt.com/codex/tasks/task_e_68e7b7a2cb14833282f1b9bd6875d40b